### PR TITLE
Add tweet truncation if the length is too long

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
 - pip install -r requirements-dev.txt
 - pip install coveralls
 before_script:
-- invoke lint && invoke validate_yaml
+- invoke lint && invoke validateyaml
 script:
 - invoke test
 after_success:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 testfixtures>=5.1.1,<6.0
-invoke>=0.18.1,<1.0
-pylint>=1.7.1,<2.0
-yamllint>=1.7,<2.0
+invoke>=0.20.4,<1.0
+pylint>=1.7.2,<2.0
+yamllint>=1.8.1,<2.0
 coverage>=4.4.1,<5.0

--- a/tasks.py
+++ b/tasks.py
@@ -43,7 +43,7 @@ def lint(ctx, pylintrc='.pylintrc', extra=''):
     'yamllintrc': 'Path to a yamllintrc file for configuring PyLint.',
     'filename': 'Path to the strings YAML file to validate.'
 })
-def validate_yaml(ctx, yamllintrc='.yamllint', filename='strings.yml'):
+def validateyaml(ctx, yamllintrc='.yamllint', filename='strings.yml'):
     """
     Use yamllint to check for errors and enforce a markup standard for the strings YAML file.
     By default this will use the '.yamllint' config file to validate 'strings.yml'.

--- a/test.py
+++ b/test.py
@@ -17,6 +17,7 @@ import unittest
 
 import forecastio
 import pytz
+import tweepy
 import yaml
 from testfixtures import LogCapture
 from testfixtures import replace
@@ -25,10 +26,11 @@ import keys
 import models
 import utils
 import weatherBot
-from test_helpers import mocked_requests_get
 from test_helpers import mocked_forecastio_manual
 from test_helpers import mocked_forecastio_manual_error
 from test_helpers import mocked_get_tweepy_api
+from test_helpers import mocked_tweepy_o_auth_handler
+from test_helpers import mocked_requests_get
 
 
 class TestUtils(unittest.TestCase):
@@ -725,6 +727,12 @@ class TestWB(unittest.TestCase):
         self.assertFalse(bytes('debug', 'UTF-8') in data)
         self.assertTrue(bytes('uh oh', 'UTF-8') in data)
         os.remove(os.path.abspath('weatherBotTest.log'))
+
+    @replace('tweepy.OAuthHandler', mocked_tweepy_o_auth_handler)
+    def test_get_tweepy_api(self):
+        """Testing getting a tweepy API object"""
+        api = weatherBot.get_tweepy_api()
+        self.assertTrue(type(api) is tweepy.API)
 
     @replace('forecastio.manual', mocked_forecastio_manual)
     def test_get_forecast_object(self):

--- a/test.py
+++ b/test.py
@@ -14,7 +14,6 @@ import os
 import pickle
 import sys
 import unittest
-from unittest import mock
 
 import forecastio
 import pytz
@@ -224,7 +223,7 @@ class WeatherLocation(unittest.TestCase):
 
 
 class WeatherBotAlert(unittest.TestCase):
-    @mock.patch('requests.get', side_effect=mocked_requests_get)
+    @replace('requests.get', mocked_requests_get)
     def test_init(self, mock_get):
         """Test that a WeatherAlert is loaded correctly"""
         forecast = forecastio.manual(os.path.join('fixtures', 'us_alert.json'))
@@ -237,8 +236,8 @@ class WeatherBotAlert(unittest.TestCase):
         self.assertEqual('a6bf597275fdf063c76a42b05c3c81ed093701b2344c3c98cfde36875f7a4c3d', alert.sha())
         self.assertEqual('<WeatherAlert: Wind Advisory at 2016-10-18 04:04:00+00:00>', str(alert))
 
-    @mock.patch('requests.get', side_effect=mocked_requests_get)
-    def test_no_expires(self, mock_get):
+    @replace('requests.get', mocked_requests_get)
+    def test_no_expires(self):
         """Test that a WeatherAlert is loaded correctly"""
         forecast = forecastio.manual(os.path.join('fixtures', 'ca_alert.json'))
         alert = models.WeatherAlert(forecast.alerts()[0])
@@ -249,8 +248,8 @@ class WeatherBotAlert(unittest.TestCase):
         self.assertEqual('d5c1870d583f95441a41d452355173bad49f60f87c2962f195bd7873f0997d4b', alert.sha())
         self.assertEqual('<WeatherAlert: Snowfall Warning at 2017-02-04 17:11:00+00:00>', str(alert))
 
-    @mock.patch('requests.get', side_effect=mocked_requests_get)
-    def test_expired(self, mock_get):
+    @replace('requests.get', mocked_requests_get)
+    def test_expired(self):
         """Test that an alert is expired or active"""
         forecast = forecastio.manual(os.path.join('fixtures', 'us_alert.json'))
         alert = models.WeatherAlert(forecast.alerts()[0])
@@ -271,8 +270,8 @@ class WeatherBotData(unittest.TestCase):
             self.weatherbot_strings = yaml.safe_load(file_stream)
         self.location = models.WeatherLocation(55.76, 12.49, 'Lyngby-Taarbæk, Hovedstaden')
 
-    @mock.patch('requests.get', side_effect=mocked_requests_get)
-    def test_init(self, mock_get):
+    @replace('requests.get', mocked_requests_get)
+    def test_init(self):
         """Testing that weather data is loaded correctly"""
         forecast = forecastio.manual(os.path.join('fixtures', 'us.json'))
         wd = models.WeatherData(forecast, self.location)
@@ -294,8 +293,8 @@ class WeatherBotData(unittest.TestCase):
         self.assertEqual(str(wd),
                          '<WeatherData: Lyngby-Taarbæk, Hovedstaden(55.76,12.49) at 2016-10-01 05:56:38+00:00>')
 
-    @mock.patch('requests.get', side_effect=mocked_requests_get)
-    def test_alerts(self, mock_get):
+    @replace('requests.get', mocked_requests_get)
+    def test_alerts(self):
         """Testing that alerts are loaded correctly into a list"""
         location = models.WeatherLocation(34.2, -118.36, 'Los Angeles, CA')
         forecast = forecastio.manual(os.path.join('fixtures', 'us_alert.json'))
@@ -304,8 +303,8 @@ class WeatherBotData(unittest.TestCase):
         self.assertEqual(wd.alerts[1].title, 'Beach Hazards Statement')
         self.assertEqual(wd.alerts[2].title, 'Red Flag Warning')
 
-    @mock.patch('requests.get', side_effect=mocked_requests_get)
-    def test_bad_data(self, mock_get):
+    @replace('requests.get', mocked_requests_get)
+    def test_bad_data(self):
         """Testing that bad data will gracefully fail"""
         forecast = forecastio.manual(os.path.join('fixtures', 'bad_data_unavailable.json'))
         wd = models.WeatherData(forecast, self.location)
@@ -317,16 +316,16 @@ class WeatherBotData(unittest.TestCase):
         wd = models.WeatherData(forecast, self.location)
         self.assertFalse(wd.valid)
 
-    @mock.patch('requests.get', side_effect=mocked_requests_get)
-    def test_optional_fields(self, mock_get):
+    @replace('requests.get', mocked_requests_get)
+    def test_optional_fields(self):
         """Testing that bad data will gracefully fail"""
         forecast = forecastio.manual(os.path.join('fixtures', 'optional_fields.json'))
         wd = models.WeatherData(forecast, self.location)
         self.assertEqual(wd.precipType, 'rain')
         self.assertEqual(wd.windBearing, 'unknown direction')
 
-    @mock.patch('requests.get', side_effect=mocked_requests_get)
-    def test_json(self, mock_get):
+    @replace('requests.get', mocked_requests_get)
+    def test_json(self):
         """Testing that json() returns a dict containing the response from the Dark Sky API"""
         forecast = forecastio.manual(os.path.join('fixtures', 'us.json'))
         wd = models.WeatherData(forecast, self.location)
@@ -339,8 +338,8 @@ class WeatherBotString(unittest.TestCase):
             self.weatherbot_strings = yaml.safe_load(file_stream)
         self.location = models.WeatherLocation(55.76, 12.49, 'Lyngby-Taarbæk, Hovedstaden')
 
-    @mock.patch('requests.get', side_effect=mocked_requests_get)
-    def test_forecast(self, mock_get):
+    @replace('requests.get', mocked_requests_get)
+    def test_forecast(self):
         """Testing that forecasts are formatted correctly"""
         forecast = forecastio.manual(os.path.join('fixtures', 'us.json'))
         wd = models.WeatherData(forecast, self.location)
@@ -357,8 +356,8 @@ class WeatherBotString(unittest.TestCase):
         self.assertEqual(forecast_string,
                          'The forecast for today is mostly cloudy throughout the day. 66ºF/50ºF. Test ending!')
 
-    @mock.patch('requests.get', side_effect=mocked_requests_get)
-    def test_normal(self, mock_get):
+    @replace('requests.get', mocked_requests_get)
+    def test_normal(self):
         """Testing that normal events are formatted"""
         forecast = forecastio.manual(os.path.join('fixtures', 'us.json'))
         wd = models.WeatherData(forecast, self.location)
@@ -367,8 +366,8 @@ class WeatherBotString(unittest.TestCase):
         normal_string = wbs.normal()
         self.assertIn(normal_string, wbs.normal_conditions)
 
-    @mock.patch('requests.get', side_effect=mocked_requests_get)
-    def test_special(self, mock_get):
+    @replace('requests.get', mocked_requests_get)
+    def test_special(self):
         """Testing if special events are triggered"""
         forecast_si = forecastio.manual(os.path.join('fixtures', 'si.json'))
         forecast_us = forecastio.manual(os.path.join('fixtures', 'us.json'))
@@ -478,8 +477,8 @@ class WeatherBotString(unittest.TestCase):
         wbs.set_weather(wd)
         self.assertEqual('dry', wbs.special().type)
 
-    @mock.patch('requests.get', side_effect=mocked_requests_get)
-    def test_alert(self, mock_get):
+    @replace('requests.get', mocked_requests_get)
+    def test_alert(self):
         """Testing that alerts are formatted"""
         wbs = models.WeatherBotString(self.weatherbot_strings)
         forecast = forecastio.manual(os.path.join('fixtures', 'ca_alert.json'))
@@ -490,8 +489,8 @@ class WeatherBotString(unittest.TestCase):
         self.assertIn('Snowfall Warning', alert)
         self.assertIn('https://weather.gc.ca/warnings/report_e.html?ab6', alert)
 
-    @mock.patch('requests.get', side_effect=mocked_requests_get)
-    def test_precipitation(self, mock_get):
+    @replace('requests.get', mocked_requests_get)
+    def test_precipitation(self):
         """Testing that precipitation conditions are met"""
         wbs = models.WeatherBotString(self.weatherbot_strings)
         forecast_us = forecastio.manual(os.path.join('fixtures', 'us.json'))
@@ -548,8 +547,8 @@ class WeatherBotString(unittest.TestCase):
         self.assertEqual(precip.type, 'very-light-rain')
         self.assertIn(precip.text, wbs.precipitations['rain']['very-light'])
 
-    @mock.patch('requests.get', side_effect=mocked_requests_get)
-    def test_update_weather_data(self, mock_get):
+    @replace('requests.get', mocked_requests_get)
+    def test_update_weather_data(self):
         """Testing that new weather data is loaded correctly"""
         forecast1 = forecastio.manual(os.path.join('fixtures', 'us.json'))
         wd1 = models.WeatherData(forecast1, self.location)
@@ -573,8 +572,8 @@ class WeatherBotString(unittest.TestCase):
         self.assertIn('https://alerts.weather.gov/cap/wwacapget.php?x=OH12561A63BE38.SevereThunderstormWarning.'
                       '12561A63C2E8OH.ILNSVSILN.f17bc0b3ead1db18bf60532894d9925e', alert)
 
-    @mock.patch('requests.get', side_effect=mocked_requests_get)
-    def test_dict(self, mock_get):
+    @replace('requests.get', mocked_requests_get)
+    def test_dict(self):
         """Testing that __dict__ returns the correct data"""
         forecast = forecastio.manual(os.path.join('fixtures', 'us.json'))
         wd = models.WeatherData(forecast, self.location)

--- a/test.py
+++ b/test.py
@@ -748,14 +748,34 @@ class TestWB(unittest.TestCase):
         self.assertEqual(bad_forecast, None)
 
     @replace('weatherBot.get_tweepy_api', mocked_get_tweepy_api)
-    def test_get_location_from_user_timeline(self):
-        """Testing getting a location from twitter account's recent tweets"""
-        fallback_loc = models.WeatherLocation(4, 3, 'test2')
+    def test_get_location_from_user_timeline_coordinates(self):
+        """Testing getting a location from twitter account's recent tweets using the coordinates property"""
+        fallback_loc = models.WeatherLocation(4, 3, 'test')
         test_loc = models.WeatherLocation(2, 1, 'test')
         loc = weatherBot.get_location_from_user_timeline('MorrisMNWeather', fallback_loc)
         self.assertTrue(type(loc) is models.WeatherLocation)
         self.assertEqual(loc, test_loc)
-        self.assertEqual(weatherBot.get_location_from_user_timeline('testuser', fallback_loc), fallback_loc)
+
+    @replace('weatherBot.get_tweepy_api', mocked_get_tweepy_api)
+    def test_get_location_from_user_timeline_place(self):
+        """Testing getting a location from twitter account's recent tweets using the place bounding box"""
+        fallback_loc = models.WeatherLocation(4, 3, 'test')
+        test_loc = models.WeatherLocation(5.0, 4.0, 'cool place')
+        loc = weatherBot.get_location_from_user_timeline('nocoords', fallback_loc)
+        self.assertTrue(type(loc) is models.WeatherLocation)
+        self.assertEqual(loc, test_loc)
+
+    @replace('weatherBot.get_tweepy_api', mocked_get_tweepy_api)
+    def test_get_location_from_user_timeline_empty(self):
+        """Testing getting a location from twitter account's recent tweets when there are none"""
+        fallback_loc = models.WeatherLocation(4, 3, 'test')
+        self.assertEqual(weatherBot.get_location_from_user_timeline('no tweets', fallback_loc), fallback_loc)
+
+    @replace('weatherBot.get_tweepy_api', mocked_get_tweepy_api)
+    def test_get_location_from_user_timeline_error(self):
+        """Testing getting a location from twitter account's recent tweets when there is an error"""
+        fallback_loc = models.WeatherLocation(4, 3, 'test')
+        self.assertEqual(weatherBot.get_location_from_user_timeline('error', fallback_loc), fallback_loc)
 
     @replace('weatherBot.get_tweepy_api', mocked_get_tweepy_api)
     def test_do_tweet(self):

--- a/test_helpers.py
+++ b/test_helpers.py
@@ -50,24 +50,32 @@ def mocked_get_tweepy_api():
             :return: list
             """
 
+            class Box:
+                def __init__(self):
+                    self.coordinates = [[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]]]
+
             class Place:
                 def __init__(self, place_name):
                     self.full_name = place_name
+                    self.bounding_box = Box()
 
             class Tweet:
                 def __init__(self):
-                    if screen_name == 'testuser':
-                        self.coordinates = {
-                            'coordinates': [3, 4]
-                        }
-                        self.place = Place('test2')
+                    if screen_name == 'nocoords':
+                        self.coordinates = None
+                        self.place = Place('cool place')
                     else:
                         self.coordinates = {
                             'coordinates': [1, 2]
                         }
                         self.place = Place('test')
 
-            return [Tweet()]
+            if screen_name == 'error':
+                raise tweepy.TweepError('uh oh')
+            elif screen_name != 'no tweets':
+                return [Tweet()]
+            else:
+                return []
 
     return API()
 

--- a/test_helpers.py
+++ b/test_helpers.py
@@ -127,3 +127,11 @@ def mocked_forecastio_manual(url):
 
 def mocked_forecastio_manual_error(url):
     raise requests.exceptions.HTTPError
+
+
+def mocked_tweepy_o_auth_handler(key, secret):
+    class Auth:
+        def set_access_token(self, token, secret):
+            pass
+
+    return Auth()

--- a/test_helpers.py
+++ b/test_helpers.py
@@ -1,0 +1,129 @@
+import json
+
+import tweepy
+import requests
+
+
+def mocked_get_tweepy_api():
+    class API:
+        """
+        Class mocking a tweepy API
+        """
+
+        def me(self):
+            """
+            get the current user's screen name
+            :return: str
+            """
+            return 'test'
+
+        def send_direct_message(self):
+            """
+            send a direct message
+            """
+
+        def update_status(self, status, lat=None, long=None):
+            """
+            Update status
+            :return: Status
+            """
+
+            class Status:
+                """
+                Class mocking a tweepy Status
+                """
+
+                def __init__(self, text):
+                    """
+                    :param text: str
+                    """
+                    self.text = text
+
+            if status == 'error':
+                raise tweepy.TweepError('error on purpose')
+            else:
+                return Status(status)
+
+        def user_timeline(self, screen_name, include_rts, count):
+            """
+            Get a user's timeline
+            :return: list
+            """
+
+            class Place:
+                def __init__(self, place_name):
+                    self.full_name = place_name
+
+            class Tweet:
+                def __init__(self):
+                    if screen_name == 'testuser':
+                        self.coordinates = {
+                            'coordinates': [3, 4]
+                        }
+                        self.place = Place('test2')
+                    else:
+                        self.coordinates = {
+                            'coordinates': [1, 2]
+                        }
+                        self.place = Place('test')
+
+            return [Tweet()]
+
+    return API()
+
+
+def mocked_requests_get(*args, **kwargs):
+    """
+    Mocked requests.get
+    :return: MockResponse
+    """
+
+    class MockResponse:
+        """
+        Class mocking the response of calling request.get in the python-forecastio library
+        """
+
+        def __init__(self, json_data, status_code):
+            self.json_data = json_data
+            self.status_code = status_code
+            self.headers = None
+
+        def raise_for_status(self):
+            """
+            This method is used to check for errors, but none will (should) exist in a mocked response
+            """
+            pass
+
+        def json(self):
+            """
+            :return: dict
+            """
+            return self.json_data
+
+    with open(args[0], 'r', encoding='utf-8') as file_stream:
+        return MockResponse(json.load(file_stream), 200)
+
+
+def mocked_forecastio_manual(url):
+    class Response:
+        def __init__(self, status_code):
+            self.status_code = status_code
+
+    class Forecast:
+        """
+        Class mocking a Forecast
+        """
+
+        def __init__(self):
+            self.response = Response(200)
+            self.json = {
+                'flags': {
+                    'units': 'us'
+                }
+            }
+
+    return Forecast()
+
+
+def mocked_forecastio_manual_error(url):
+    raise requests.exceptions.HTTPError

--- a/weatherBot.py
+++ b/weatherBot.py
@@ -218,21 +218,30 @@ def do_tweet(text, weather_location, tweet_location, variable_location, hashtag=
     :return: a tweepy status object
     """
     api = get_tweepy_api()
-    if hashtag:
-        text += ' ' + hashtag
-    logging.debug('Trying to tweet: %s', text)
+    body = text
+    # account for space before hashtag
+    max_length = 139 - len(hashtag) if hashtag else 140
+
     if variable_location:
-        text = weather_location.name + ': ' + text
+        body = weather_location.name + ': ' + body
+
+    logging.debug('Trying to tweet: %s', body)
+    if len(body) > max_length:
+        body = body[:(max_length - 3)] + '...'
+        logging.warning('Status text is too long, tweeting the following instead: %s', body)
+
+    if hashtag:
+        body += ' ' + hashtag
     try:
         if tweet_location:
-            status = api.update_status(status=text, lat=weather_location.lat, long=weather_location.lng)
+            status = api.update_status(status=body, lat=weather_location.lat, long=weather_location.lng)
         else:
-            status = api.update_status(status=text)
-        logging.info('Tweet success: %s', text)
+            status = api.update_status(status=body)
+        logging.info('Tweet success: %s', body)
         return status
     except tweepy.TweepError as err:
         logging.error('Tweet failed: %s', err.reason)
-        logging.warning('Tweet skipped due to error: %s', text)
+        logging.warning('Tweet skipped due to error: %s', body)
         return None
 
 

--- a/weatherBot.py
+++ b/weatherBot.py
@@ -227,7 +227,8 @@ def do_tweet(text, weather_location, tweet_location, variable_location, hashtag=
 
     logging.debug('Trying to tweet: %s', body)
     if len(body) > max_length:
-        body = body[:(max_length - 3)] + '...'
+        # horizontal ellipsis
+        body = body[:(max_length - 1)] + '\u2026'
         logging.warning('Status text is too long, tweeting the following instead: %s', body)
 
     if hashtag:


### PR DESCRIPTION
Unit tests still need to be written. This would be an excellent PR to mock the `tweepy.api.update_status` method for testing the `do_tweet` function. I'll look into this when I have the time.