### PR TITLE
Update and pin deps, fix linting warning

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 testfixtures>=6.10.0,<7
 invoke>=1.3.0,<2
-pylint>=2.3.1,<3
-yamllint>=1.17.0,<2
+pylint==2.4.2
+yamllint==1.17.0
 coverage>=4.5.4,<5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 tweepy==3.8.0
-python-forecastio>=1.4.0,<2
+python-forecastio==1.4.0
 pytz>=2019.2
-PyYAML>=5.1.2,<6
+PyYAML==5.1.2

--- a/weatherBot.py
+++ b/weatherBot.py
@@ -399,7 +399,7 @@ def main(path):
         except yaml.YAMLError as err:
             logging.error(err, exc_info=True)
             logging.error('Could not read YAML file, please correct, run yamllint, and try again.')
-            exit()
+            sys.exit()
 
     location = CONFIG['default_location']
     updated_time = utils.datetime_to_utc('UTC', datetime.utcnow()) - timedelta(minutes=30)


### PR DESCRIPTION
The Travis cron job failed due to pylon being updated and dropping the linting rating. This PR pins several dependencies to the latest version (as of right now) and fixes the linting warning.